### PR TITLE
Preserve signs when simlifying

### DIFF
--- a/Sources/FractionKit/Fraction.swift
+++ b/Sources/FractionKit/Fraction.swift
@@ -93,7 +93,19 @@ public struct Fraction: Equatable {
 
   public var simplify: Fraction {
     let gcd = computeGCD(numerator, denominator)
-    return Fraction(numerator: numerator / gcd, denominator: denominator / gcd)
+    // we probably shouldn't changed signedness as a result of simplification
+    let n = matchSign(of: numerator / gcd, to: numerator)
+    let d = matchSign(of: denominator / gcd, to: denominator)
+    return Fraction(numerator: n, denominator: d)
+  }
+
+  private func matchSign(of value: Int, to referenceValue: Int) -> Int {
+    switch (value < 0, referenceValue < 0) {
+    case (true, true), (false, false):
+      return value
+    case (true, false), (false, true):
+      return value * -1
+    }
   }
 
   // Thank you, Ray

--- a/Tests/FractionsTests/FractionTests.swift
+++ b/Tests/FractionsTests/FractionTests.swift
@@ -200,6 +200,11 @@ final class FractionTests: XCTestCase {
     XCTAssertEqual(f.simplify, Fraction(numerator: 5, denominator: 2))
   }
 
+  func testSimplifyNegative() {
+    let f = Fraction(numerator: -1, denominator: 2)
+    XCTAssertEqual(f.simplify, Fraction(numerator: -1, denominator: 2))
+  }
+
   static var allTests = [
     ("testEmptyString", testEmptyString),
   ]


### PR DESCRIPTION
I noticed this last weekend. I think the results are still technically correct, but it's an unexpected change and the output doesn't look as nice.